### PR TITLE
Variable Naming - pada metode setSpouse

### DIFF
--- a/TaxCalculator/TaxCalculator/src/lib/Employee.java
+++ b/TaxCalculator/TaxCalculator/src/lib/Employee.java
@@ -69,7 +69,7 @@ public class Employee {
 
     public void setSpouse(String spouseName, String spouseIdNumber) {
         this.spouseName = spouseName;
-        this.spouseIdNumber = idNumber;
+        this.spouseIdNumber = spouseidNumber;
     }
 
     public void addChild(String childName, String childIdNumber) {


### PR DESCRIPTION
Dalam metode setSpouse, variabel spouseIdNumber yang digunakan untuk menginisialisasi this.spouseIdNumber seharusnya yaitu parameter yang diterima oleh metode tersebut, bukan idNumber.